### PR TITLE
Support Ruby 3.2.

### DIFF
--- a/stanford-core-nlp.gemspec
+++ b/stanford-core-nlp.gemspec
@@ -18,7 +18,7 @@ recognition and coreference resolution for English. }
   s.files = Dir['lib/**/*'] + Dir['bin/**/*'] + ['README.md', 'LICENSE']
 
   # Runtime dependencies
-  s.add_runtime_dependency 'bind-it', '~>0.2.7'
+  s.add_runtime_dependency 'bind-it'
 
   # Development dependency.
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
Simple change that removes the constraint on [bind-it](https://github.com/louismullie/bind-it) to version 0.2.7, which was not compatible with newer versions of Ruby.